### PR TITLE
Added WarshipPorn and WarplanePorn

### DIFF
--- a/openseadragonizer-bot.py
+++ b/openseadragonizer-bot.py
@@ -19,7 +19,7 @@ db_conn.commit()
 logging.info('SQLite connection initialized.')
 
 
-subreddit = 'earthporn+mapporn+space'
+subreddit = 'earthporn+mapporn+space+warshipporn+warplaneporn'
 
 user_agent = "OpenSeadragonizer:v0.0.0 (by /u/openseadragonizer)"
 r = praw.Reddit(user_agent = user_agent)


### PR DESCRIPTION
High resolution images are fairly regularly posted to the image-based subreddits [WarshipPorn ](https://www.reddit.com/r/WarshipPorn/)and [WarplanePorn](https://www.reddit.com/r/WarplanePorn/), and having openseadragonbot monitor these subreddits would be great.

I've added both subreddits to the config file.